### PR TITLE
Only process tabs with ‘tabview-tab’ extData

### DIFF
--- a/options_ui.js
+++ b/options_ui.js
@@ -25,8 +25,10 @@ filePicker.addEventListener("change", picker => {
 
         const tabs = [];
         for(const tab of w.tabs) {
-          const extData = JSON.parse(tab.extData['tabview-tab']);
-          tabs.push({url: tab.entries[0].url, container: windowTabContainers[Number(extData.groupID)-1]});
+	      if(tab.extData['tabview-tab']) {
+		    const extData = JSON.parse(tab.extData['tabview-tab']);
+            tabs.push({url: tab.entries[0].url, container: windowTabContainers[Number(extData.groupID)-1]});
+	      }
         }
         windows.push(tabs);
       }


### PR DESCRIPTION
There were several pinned tabs without tab.extData['tabview-tab'] that were causing the JSON.parse() call to fail. This should fix that specific scenario for other users with similar issues.